### PR TITLE
Nano updates for master-next

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-2gb-devkit
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-2gb-devkit
@@ -1,0 +1,1 @@
+jetson-nano-qspi-sd

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-qspi-sd/flash_mender.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-qspi-sd/flash_mender.xml
@@ -48,21 +48,22 @@
               binary. </description>
         </partition>
 
-        <!-- This is padding to ensure VER is at the end of flash -->
-        <partition name="PAD" id="6" type="data">
+        <partition name="UBENV" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 3342336 </size>
+	    <start_location> 0x3B0000 </start_location>
+            <size> 131072 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <description> Empty padding. </description>
+            <description> U-Boot environment area  </description>
         </partition>
 
-        <partition name="VER_b" id="7" type="data">
+        <partition name="VER_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 65536 </size>
+	    <start_location> 0x3E0000 </start_location>
+            <size> 32768 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>
@@ -72,10 +73,11 @@
               information. </description>
         </partition>
 
-        <partition name="VER" id="8" type="data">
+        <partition name="VER" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 65536 </size>
+	    <start_location> 0x3F0000 </start_location>
+            <size> 32768 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0003-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0003-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -1,0 +1,49 @@
+From 2edf2da1a9ebaa4d7233a39126832adf968e36cb Mon Sep 17 00:00:00 2001
+From: Marcin Pasinski <marcin.pasinski@northern.tech>
+Date: Wed, 31 Jan 2018 18:10:04 +0100
+Subject: [PATCH] Integration of Mender boot code into U-Boot.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
+Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>
+
+---
+ include/env_default.h     | 3 +++
+ scripts/Makefile.autoconf | 3 ++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index a657927e06..8b7442c04d 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -10,6 +10,8 @@
+ #include <env_callback.h>
+ #include <linux/stringify.h>
+ 
++#include <env_mender.h>
++
+ #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
+ env_t embedded_environment __UBOOT_ENV_SECTION__(environment) = {
+ 	ENV_CRC,	/* CRC Sum */
+@@ -22,6 +24,7 @@ static char default_environment[] = {
+ #else
+ const uchar default_environment[] = {
+ #endif
++	MENDER_ENV_SETTINGS
+ #ifndef CONFIG_USE_DEFAULT_ENV_FILE
+ #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
+ 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
+diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
+index 00b8fb34aa..e312c8037d 100644
+--- a/scripts/Makefile.autoconf
++++ b/scripts/Makefile.autoconf
+@@ -109,7 +109,8 @@ define filechk_config_h
+ 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
+ 	echo \#include \<asm/config.h\>;				\
+ 	echo \#include \<linux/kconfig.h\>;				\
+-	echo \#include \<config_fallbacks.h\>;)
++	echo \#include \<config_fallbacks.h\>;				\
++	echo \#include \<config_mender.h\>;)
+ endef
+ 
+ include/config.h: scripts/Makefile.autoconf create_symlink FORCE

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0012-p3541-0000_defconfig-Mender-patch.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0012-p3541-0000_defconfig-Mender-patch.patch
@@ -1,0 +1,39 @@
+From 3d47f6c54c493814f3f1f390efa4a14f86ccc0f5 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Fri, 30 Oct 2020 14:29:08 -0700
+Subject: [PATCH] p3541-0000_defconfig: Mender patch
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+
+%% original patch: 0012-p3541-0000_defconfig-Mender-patch.patch
+---
+ configs/p3541-0000_defconfig | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/configs/p3541-0000_defconfig b/configs/p3541-0000_defconfig
+index 19b197d834..424b4b3bb5 100644
+--- a/configs/p3541-0000_defconfig
++++ b/configs/p3541-0000_defconfig
+@@ -1,8 +1,10 @@
+ CONFIG_ARM=y
+ CONFIG_ARCH_TEGRA=y
+ CONFIG_SYS_TEXT_BASE=0x80080000
+-CONFIG_ENV_SIZE=0x8000
+-CONFIG_ENV_OFFSET=0x3D8000
++CONFIG_ENV_SIZE=0x10000
++CONFIG_ENV_OFFSET=0x3b0000
++CONFIG_ENV_OFFSET_REDUND=0x3c0000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_ENV_SECT_SIZE=0x1000
+ CONFIG_NR_DRAM_BANKS=16
+ CONFIG_TEGRA210=y
+@@ -57,3 +59,6 @@ CONFIG_CI_UDC=y
+ CONFIG_USB_GADGET_DOWNLOAD=y
+ CONFIG_USB_HOST_ETHER=y
+ CONFIG_USB_ETHER_ASIX=y
++CONFIG_BOOTCOUNT_LIMIT=y
++CONFIG_BOOTCOUNT_ENV=y
++# CONFIG_BOOTCOMMAND is not set
+-- 
+2.25.1
+

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Reduce-env-size-on-p3450-0000-to-64KiB.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Reduce-env-size-on-p3450-0000-to-64KiB.patch
@@ -1,0 +1,29 @@
+From 00d2500c1a78e3b49d70256e5cbea6aedb3ebe83 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 2 Nov 2020 08:24:14 -0800
+Subject: [PATCH] Reduce env size on p3450-0000 to 64KiB
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ configs/p3450-0000_defconfig | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configs/p3450-0000_defconfig b/configs/p3450-0000_defconfig
+index e391b00bda..f11607d4ff 100644
+--- a/configs/p3450-0000_defconfig
++++ b/configs/p3450-0000_defconfig
+@@ -54,9 +54,9 @@ CONFIG_CI_UDC=y
+ CONFIG_USB_GADGET_DOWNLOAD=y
+ CONFIG_USB_HOST_ETHER=y
+ CONFIG_USB_ETHER_ASIX=y
+-CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_SIZE=0x10000
+ CONFIG_ENV_OFFSET=0x3b0000
+-CONFIG_ENV_OFFSET_REDUND=0x3d0000
++CONFIG_ENV_OFFSET_REDUND=0x3c0000
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ # CONFIG_ENV_IS_NOWHERE is not set
+ # CONFIG_ENV_IS_IN_EEPROM is not set
+-- 
+2.25.1
+

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra-vars.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra-vars.inc
@@ -1,6 +1,10 @@
 MENDER_UBOOT_AUTO_CONFIGURE = "0"
 MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART = "2"
 
+TEGRA_MENDER_BOOTENV_SIZE_DEFAULT = "0x20000"
+TEGRA_MENDER_BOOTENV_SIZE_DEFAULT_tegra210 = "${@'0x10000' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '0x20000'}"
+BOOTENV_SIZE ?= "${TEGRA_MENDER_BOOTENV_SIZE_DEFAULT}"
+
 # Calculate this offset by adding up the offsets of each partition preceeding the uboot_env partition in sdmmc_boot and aligning to the next
 # 4096 byte boundary, then subtracting 4 MiB (4194304) since the sdmmc_boot represents the combined boot0 and boot1 partitions
 # Please note the suggestions in the nvidia thread at https://devtalk.nvidia.com/default/topic/1063652/jetson-tx2/mmcblk0boot1-usage-at-address-4177408-and-u-boot-parameter-storage-space-availability/

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modified.patch"
 SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
 SRC_URI_append_mender-uboot = " file://0012-p3541-0000_defconfig-Mender-patch.patch"
+SRC_URI_append_mender-uboot = " file://0013-Reduce-env-size-on-p3450-0000-to-64KiB.patch"
 
 do_provide_mender_defines_append_tegra210() {
     if [ "${TEGRA_SPIFLASH_BOOT}" = "1" ]; then

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 
 SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modified.patch"
 SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
+SRC_URI_append_mender-uboot = " file://0012-p3541-0000_defconfig-Mender-patch.patch"
 
 do_provide_mender_defines_append_tegra210() {
     if [ "${TEGRA_SPIFLASH_BOOT}" = "1" ]; then


### PR DESCRIPTION
* U-Boot patches:
  * replace one of the mender-core U-Boot patches with a copy that patches cleanly into the v2020.07 code base
  * add Mender integration for the Nano 2GB dev kit
* Flash layout updates:
  * Fix an issue with the SPI flash layout for `jetson-nano-qspi-sd`
  * Add support for `jetson-nano-2gb-devkit` (identical layout as for the 4GB model)

These changes track the `master` branch in meta-tegra, which is now at L4T R32.4.4 and has support for the Nano 2GB devkit.

The flash layout fix for `jetson-nano-qspi-sd` also needs back-porting to `dunfell`, since the problem occurs with L4T R32.4.3 as well.