### PR TITLE
Additional partition layout fix

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-emmc/flash_mender.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-emmc/flash_mender.xml
@@ -4,7 +4,7 @@
 
 <partition_layout version="01.00.0000">
     <device type="sdmmc" instance="3">
-        <partition name="BCT" id="2" type="boot_config_table">
+        <partition name="BCT" type="boot_config_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -12,7 +12,7 @@
             <description> **Required.** Contains Boot Configuration Table (BCT). </description>
         </partition>
 
-        <partition name="NXC" id="3" type="NVCTYPE">
+        <partition name="NXC" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -21,7 +21,7 @@
             <description> **Required.** Contains TegraBoot binary. </description>
         </partition>
 
-        <partition name="PT" id="4" type="partition_table">
+        <partition name="PT" type="partition_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -30,7 +30,7 @@
             <description> **Required.** Contains Partition Table. </description>
         </partition>
 
-        <partition name="TXC" id="5" type="TBCTYPE">
+        <partition name="TXC" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -39,7 +39,7 @@
             <description> **Required.** Contains TegraBoot CPU-side binary. </description>
         </partition>
 
-        <partition name="RP1" id="6" type="data">
+        <partition name="RP1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -48,7 +48,7 @@
             <description> **Required.** Contains Bootloader DTB binary. </description>
         </partition>
 
-        <partition name="EBT" id="7" type="bootloader">
+        <partition name="EBT" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 655360 </size>
@@ -58,7 +58,7 @@
               that loads the binary in kernel partition. </description>
         </partition>
 
-        <partition name="WX0" id="8" type="WB0TYPE">
+        <partition name="WX0" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -67,7 +67,7 @@
             <description> **Required.** Contains warm boot binary. </description>
         </partition>
 
-        <partition name="BXF" id="9" type="data">
+        <partition name="BXF" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -76,7 +76,7 @@
             <description> **Required.** Contains SC7 entry firmware. </description>
         </partition>
 
-        <partition name="BXF-DTB" id="10" type="data">
+        <partition name="BXF-DTB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -87,7 +87,7 @@
             <description> **Optional.** Reserved for future use by BPMP DTB binary; can't remove </description>
         </partition>
 
-        <partition name="NXC-1" id="11" type="NVCTYPE">
+        <partition name="NXC-1" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -97,7 +97,7 @@
               binary. </description>
         </partition>
 
-        <partition name="PT-1" id="12" type="partition_table">
+        <partition name="PT-1" type="partition_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -107,7 +107,7 @@
               Table. </description>
         </partition>
 
-        <partition name="TXC-1" id="13" type="TBCTYPE">
+        <partition name="TXC-1" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -116,7 +116,7 @@
             <description> **Required.** Contains a redundant copy of TegraBoot CPU-side binary. </description>
         </partition>
 
-        <partition name="RP1-1" id="14" type="data">
+        <partition name="RP1-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -126,7 +126,7 @@
               DTB binary. </description>
         </partition>
 
-        <partition name="EBT-1" id="15" type="bootloader">
+        <partition name="EBT-1" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 655360 </size>
@@ -135,7 +135,7 @@
             <description> **Required.** Contains a redundant copy of CBoot. </description>
         </partition>
 
-        <partition name="WX0-1" id="16" type="WB0TYPE">
+        <partition name="WX0-1" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -145,7 +145,7 @@
               warm boot binary. </description>
         </partition>
 
-        <partition name="BXF-1" id="17" type="data">
+        <partition name="BXF-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -155,7 +155,7 @@
               SC7 Entry Firmware. </description>
         </partition>
 
-        <partition name="BXF-DTB-1" id="18" type="data">
+        <partition name="BXF-DTB-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -167,7 +167,7 @@
         </partition>
 
         <!-- This is padding to ensure VER is at the end of flash -->
-        <partition name="PAD" id="19" type="data">
+        <partition name="PAD" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 917504 </size>
@@ -177,7 +177,7 @@
             <description> **Required.** Empty padding. </description>
         </partition>
 
-        <partition name="VER_b" id="20" type="data">
+        <partition name="VER_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -190,7 +190,7 @@
               BSP version info. </description>
         </partition>
 
-        <partition name="VER" id="21" type="data">
+        <partition name="VER" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -204,7 +204,7 @@
     </device>
 
     <device type="sdmmc" instance="3">
-        <partition name="GP1" id="22" type="GP1">
+        <partition name="GP1" type="GP1">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -214,7 +214,7 @@
               by standard partition tools such as gdisk and parted. </description>
         </partition>
 
-        <partition name="APP" id="23" type="data">
+        <partition name="APP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> APPSIZE </size>
@@ -225,7 +225,7 @@
               `/dev/mmcblk0p1`. </description>
         </partition>
 
-        <partition name="DXB" id="24" type="data">
+        <partition name="DXB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -234,7 +234,7 @@
             <description> **Required.** Contains kernel DTB binary. </description>
         </partition>
 
-        <partition name="TXS" id="25" type="data">
+        <partition name="TXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 6291456 </size>
@@ -243,7 +243,7 @@
             <description> **Required.** Contains TOS binary. </description>
         </partition>
 
-        <partition name="EXS" id="26" type="data">
+        <partition name="EXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 81920 </size>
@@ -252,7 +252,7 @@
             <description> **Optional.** Contains the encrypted keys. </description>
         </partition>
 
-        <partition name="LNX" id="27" type="data">
+        <partition name="LNX" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 67092480 </size>
@@ -262,7 +262,7 @@
               the rootfs at `/boot`. </description>
         </partition>
 
-        <partition name="DXB-1" id="28" type="data">
+        <partition name="DXB-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -272,7 +272,7 @@
               kernel DTB binary. </description>
         </partition>
 
-        <partition name="TXS-1" id="29" type="data">
+        <partition name="TXS-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 6291456 </size>
@@ -282,7 +282,7 @@
               TOS binary. </description>
         </partition>
 
-        <partition name="EXS-1" id="30" type="data">
+        <partition name="EXS-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 81920 </size>
@@ -292,7 +292,7 @@
               keys. </description>
         </partition>
 
-        <partition name="LNX-1" id="31" type="data">
+        <partition name="LNX-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 67092480 </size>
@@ -302,7 +302,7 @@
               launches the kernel from the rootfs at `/boot`. </description>
         </partition>
 
-        <partition name="BMP" id="32" type="data">
+        <partition name="BMP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -312,7 +312,7 @@
               boot. </description>
         </partition>
 
-        <partition name="RP4" id="33" type="data">
+        <partition name="RP4" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -322,7 +322,7 @@
               true USB 3.0 compliant host controller. </description>
         </partition>
 
-        <partition name="RECNAME" id="34" type="data">
+        <partition name="RECNAME" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size>  66060288 </size>
@@ -331,7 +331,7 @@
             <description> **Optional.** Reserved for future use by the recovery image; removable. </description>
         </partition>
 
-        <partition name="RECDTB-NAME" id="35" type="data">
+        <partition name="RECDTB-NAME" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 524288 </size>
@@ -341,7 +341,7 @@
               removable. </description>
         </partition>
 
-        <partition name="BOOTCTRLNAME" id="36" type="data">
+        <partition name="BOOTCTRLNAME" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -350,7 +350,7 @@
             <description> **Optional.** Reserved for future use by boot control data; removable. </description>
         </partition>
 
-        <partition name="BOOTCTRLNAME_b" id="37" type="data">
+        <partition name="BOOTCTRLNAME_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -360,7 +360,7 @@
               removable. </description>
         </partition>
 
-        <partition name="RECROOTFS" id="38" type="data">
+        <partition name="RECROOTFS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 314572800 </size>
@@ -371,14 +371,14 @@
               removable. </description>
         </partition>
 
-        <partition name="ENV" id="39" type="data">
+        <partition name="ENV" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
             <allocation_attribute> 8 </allocation_attribute>
         </partition>
 
-        <partition name="APP_b" id="40" type="data">
+        <partition name="APP_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> APPSIZE </size>
@@ -386,7 +386,7 @@
             <filename> APPFILE </filename>
         </partition>
 
-        <partition name="UDA" id="41" type="data">
+        <partition name="UDA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -394,7 +394,7 @@
             <filename> DATAFILE </filename>
         </partition>
 
-        <partition name="GPT" id="42" type="GPT">
+        <partition name="GPT" type="GPT">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> -1 </size>

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-qspi-sd/flash_mender.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-qspi-sd/flash_mender.xml
@@ -4,7 +4,7 @@
 
 <partition_layout version="01.00.0000">
     <device type="spi" instance="0">
-        <partition name="BCT" id="2" type="boot_config_table">
+        <partition name="BCT" type="boot_config_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -14,7 +14,7 @@
             <description> **Required.** Contains Boot Configuration Table (BCT). </description>
         </partition>
 
-        <partition name="NXC" id="3" type="NVCTYPE">
+        <partition name="NXC" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -25,7 +25,7 @@
             <description> **Required.** Contains TegraBoot binary. </description>
         </partition>
 
-        <partition name="PT" id="4" type="partition_table">
+        <partition name="PT" type="partition_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -36,7 +36,7 @@
             <description> **Required.** Contains Partition Table. </description>
         </partition>
 
-        <partition name="NXC_R" id="5" type="NVCTYPE">
+        <partition name="NXC_R" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -88,7 +88,7 @@
 
     </device>
     <device type="sdcard" instance="0">
-        <partition name="GP1" id="9" type="GP1">
+        <partition name="GP1" type="GP1">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -100,7 +100,7 @@
               by standard partition tools such as gdisk and parted. </description>
         </partition>
 
-        <partition name="APP" id="10" type="data">
+        <partition name="APP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> APPSIZE </size>
@@ -114,7 +114,7 @@
               `/dev/mmcblk0p1`. </description>
         </partition>
 
-        <partition name="TXC" id="11" type="TBCTYPE">
+        <partition name="TXC" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -125,7 +125,7 @@
             <description> **Required.** Contains TegraBoot CPU-side binary. </description>
         </partition>
 
-        <partition name="RP1" id="12" type="data">
+        <partition name="RP1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -136,7 +136,7 @@
             <description> **Required.** Contains Bootloader DTB binary. </description>
         </partition>
 
-        <partition name="EBT" id="13" type="bootloader">
+        <partition name="EBT" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 589824 </size>
@@ -148,7 +148,7 @@
               binary that loads the binary in the kernel partition.. </description>
         </partition>
 
-        <partition name="WX0" id="14" type="WB0TYPE">
+        <partition name="WX0" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -159,7 +159,7 @@
             <description> **Required.** Contains warm boot binary. </description>
         </partition>
 
-        <partition name="BXF" id="15" type="data">
+        <partition name="BXF" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -171,7 +171,7 @@
             <description> **Required.** Contains SC7 entry firmware. </description>
         </partition>
 
-        <partition name="BXF-DTB" id="16" type="data">
+        <partition name="BXF-DTB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 393216 </size>
@@ -182,7 +182,7 @@
             <description> **Optional.** Reserved for future use by BPMP DTB binary; can't remove. </description>
         </partition>
 
-        <partition name="FX" id="17" type="FBTYPE">
+        <partition name="FX" type="FBTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -193,7 +193,7 @@
             <description> **Optional.** Reserved for fuse bypass; removeable. </description>
         </partition>
 
-        <partition name="TXS" id="18" type="data">
+        <partition name="TXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -205,7 +205,7 @@
             <description> **Required.** Contains TOS binary. </description>
         </partition>
 
-        <partition name="DXB" id="19" type="data">
+        <partition name="DXB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -216,7 +216,7 @@
             <description> **Required.** Contains kernel DTB binary. </description>
         </partition>
 
-        <partition name="LNX" id="20" type="data">
+        <partition name="LNX" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 786432 </size>
@@ -228,7 +228,7 @@
               the rootfs at `/boot`. </description>
         </partition>
 
-        <partition name="EXS" id="21" type="data">
+        <partition name="EXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -240,7 +240,7 @@
             <description> **Optional.** Contains the encrypted keys. </description>
         </partition>
 
-        <partition name="BMP" id="22" type="data">
+        <partition name="BMP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 81920 </size>
@@ -252,7 +252,7 @@
               boot. </description>
         </partition>
 
-        <partition name="RP4" id="23" type="data">
+        <partition name="RP4" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -264,7 +264,7 @@
               a true USB 3.0 compliant host controller. </description>
         </partition>
 
-        <partition name="APP_b" id="24" type="data">
+        <partition name="APP_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> APPSIZE </size>
@@ -275,7 +275,7 @@
             <filename> APPFILE </filename>
         </partition>
 
-        <partition name="UDA" id="25" type="data">
+        <partition name="UDA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -283,7 +283,7 @@
             <filename> DATAFILE </filename>
         </partition>
 
-        <partition name="GPT" id="26" type="GPT">
+        <partition name="GPT" type="GPT">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/tegra210/flash_mender.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/tegra210/flash_mender.xml
@@ -4,7 +4,7 @@
 
 <partition_layout version="01.00.0000">
     <device type="sdmmc" instance="3">
-        <partition name="BCT" id="2" type="boot_config_table">
+        <partition name="BCT" type="boot_config_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -12,7 +12,7 @@
             <description> **Required.** Contains Boot Configuration Table (BCT). </description>
         </partition>
 
-        <partition name="NXC" id="3" type="NVCTYPE">
+        <partition name="NXC" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 376832 </size>
@@ -21,7 +21,7 @@
             <description> **Required.** Contains TegraBoot binary. </description>
         </partition>
 
-        <partition name="PT" id="4" type="partition_table">
+        <partition name="PT" type="partition_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -30,7 +30,7 @@
             <description> **Required.** Contains Partition Table. </description>
         </partition>
 
-        <partition name="TXC" id="5" type="TBCTYPE">
+        <partition name="TXC" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -39,7 +39,7 @@
             <description> **Required.** Contains TegraBoot CPU-side binary. </description>
         </partition>
 
-        <partition name="RP1" id="6" type="data">
+        <partition name="RP1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -48,7 +48,7 @@
             <description> **Required.** Contains Bootloader DTB binary. </description>
         </partition>
 
-        <partition name="EBT" id="7" type="bootloader">
+        <partition name="EBT" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 999424 </size>
@@ -58,7 +58,7 @@
               that loads the binary in the kernel partition. </description>
         </partition>
 
-        <partition name="WX0" id="8" type="WB0TYPE">
+        <partition name="WX0" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -67,7 +67,7 @@
             <description> **Required.** Contains warm boot binary. </description>
         </partition>
 
-        <partition name="BXF" id="9" type="data">
+        <partition name="BXF" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -76,7 +76,7 @@
             <description> **Required.** Contains SC7 entry firmware. </description>
         </partition>
 
-        <partition name="NXC-1" id="10" type="NVCTYPE">
+        <partition name="NXC-1" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 376832 </size>
@@ -86,7 +86,7 @@
               TegraBoot binary. </description>
         </partition>
 
-        <partition name="PT-1" id="11" type="partition_table">
+        <partition name="PT-1" type="partition_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -96,7 +96,7 @@
               Partition Table. </description>
         </partition>
 
-        <partition name="TXC-1" id="12" type="TBCTYPE">
+        <partition name="TXC-1" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -106,7 +106,7 @@
               binary. </description>
         </partition>
 
-        <partition name="RP1-1" id="13" type="data">
+        <partition name="RP1-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -116,7 +116,7 @@
               binary. </description>
         </partition>
 
-        <partition name="EBT-1" id="14" type="bootloader">
+        <partition name="EBT-1" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 999424 </size>
@@ -126,7 +126,7 @@
               CPU bootloader binary. </description>
         </partition>
 
-        <partition name="WX0-1" id="15" type="WB0TYPE">
+        <partition name="WX0-1" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -136,7 +136,7 @@
               binary. </description>
         </partition>
 
-        <partition name="BXF-1" id="16" type="data">
+        <partition name="BXF-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -147,7 +147,7 @@
         </partition>
 
         <!-- This is padding to ensure VER is at the end of flash -->
-        <partition name="PAD" id="17" type="data">
+        <partition name="PAD" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 917504 </size>
@@ -157,7 +157,7 @@
             <description> **Required.** Empty padding. </description>
         </partition>
 
-        <partition name="VER_b" id="18" type="data">
+        <partition name="VER_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -170,7 +170,7 @@
               information. </description>
         </partition>
 
-        <partition name="VER" id="19" type="data">
+        <partition name="VER" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -184,7 +184,7 @@
     </device>
 
     <device type="sdmmc" instance="3">
-        <partition name="GP1" id="20" type="GP1">
+        <partition name="GP1" type="GP1">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -194,7 +194,7 @@
               accessible by standard partition tools such as gdisk and parted. </description>
         </partition>
 
-        <partition name="APP" id="21" type="data">
+        <partition name="APP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> APPSIZE </size>
@@ -205,7 +205,7 @@
               `/dev/mmcblk0p1`. </description>
         </partition>
 
-        <partition name="DXB" id="22" type="data">
+        <partition name="DXB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -214,7 +214,7 @@
             <description> **Required.** Contains kernel DTB binary. </description>
         </partition>
 
-        <partition name="TXS" id="23" type="data">
+        <partition name="TXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 6291456 </size>
@@ -223,7 +223,7 @@
             <description> **Required.** Contains TOS binary. </description>
         </partition>
 
-        <partition name="EXS" id="24" type="data">
+        <partition name="EXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 81920 </size>
@@ -232,7 +232,7 @@
             <description> **Optional.** Contains the encrypted keys. </description>
         </partition>
 
-        <partition name="LNX" id="25" type="data">
+        <partition name="LNX" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 67092480 </size>
@@ -242,7 +242,7 @@
               from the rootfs at `/boot`. </description>
         </partition>
 
-        <partition name="DXB-1" id="26" type="data">
+        <partition name="DXB-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 1048576 </size>
@@ -252,7 +252,7 @@
               binary. </description>
         </partition>
 
-        <partition name="TXS-1" id="27" type="data">
+        <partition name="TXS-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 6291456 </size>
@@ -261,7 +261,7 @@
             <description> **Required.** Contains a redundant copy of the TOS binary. </description>
         </partition>
 
-        <partition name="EXS-1" id="28" type="data">
+        <partition name="EXS-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 81920 </size>
@@ -271,7 +271,7 @@
               keys. </description>
         </partition>
 
-        <partition name="LNX-1" id="29" type="data">
+        <partition name="LNX-1" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 67092480 </size>
@@ -281,7 +281,7 @@
               launches the kernel from the rootfs at `/boot`. </description>
         </partition>
 
-        <partition name="BMP" id="30" type="data">
+        <partition name="BMP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -291,7 +291,7 @@
               during boot. </description>
         </partition>
 
-        <partition name="RP4" id="31" type="data">
+        <partition name="RP4" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -301,7 +301,7 @@
               USB 3.0 compliant host controller. </description>
         </partition>
 
-        <partition name="RECNAME" id="32" type="data">
+        <partition name="RECNAME" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size>  66060288 </size>
@@ -310,7 +310,7 @@
             <description> **Optional.** Reserved for future use by the recovery image; removable. </description>
         </partition>
 
-        <partition name="RECDTB-NAME" id="33" type="data">
+        <partition name="RECDTB-NAME" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 524288 </size>
@@ -320,7 +320,7 @@
               removable. </description>
         </partition>
 
-        <partition name="BOOTCTRLNAME" id="34" type="data">
+        <partition name="BOOTCTRLNAME" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -329,7 +329,7 @@
             <description> **Optional.** Reserved for future use by boot control data; removable. </description>
         </partition>
 
-        <partition name="BOOTCTRLNAME_b" id="35" type="data">
+        <partition name="BOOTCTRLNAME_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
@@ -339,7 +339,7 @@
               removable. </description>
         </partition>
 
-        <partition name="EXI" id="36" type="data">
+        <partition name="EXI" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> EFISIZE </size>
@@ -351,7 +351,7 @@
             <description> **Optional.** Reserved for EFI image; removeable. </description>
         </partition>
 
-        <partition name="NXT" id="37" type="NCTTYPE">
+        <partition name="NXT" type="NCTTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -362,7 +362,7 @@
             <description> **Optional.** Reserved for NCT image; removeable. </description>
         </partition>
 
-        <partition name="MXB" id="38" type="MPBTYPE">
+        <partition name="MXB" type="MPBTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 6291456 </size>
@@ -374,7 +374,7 @@
             <description> **Optional.** Reserved for MTS pre-boot image; removeable. </description>
         </partition>
 
-        <partition name="MXP" id="39" type="MBPTYPE">
+        <partition name="MXP" type="MBPTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 6291456 </size>
@@ -386,7 +386,7 @@
             <description> **Optional.** Reserved for MTS boot pack image; removeable. </description>
         </partition>
 
-        <partition name="USP" id="40" type="data">
+        <partition name="USP" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -396,7 +396,7 @@
             <description> **Optional.** Reserved; removeable. </description>
         </partition>
 
-        <partition name="RECROOTFS" id="41" type="data">
+        <partition name="RECROOTFS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 314572800 </size>
@@ -407,7 +407,7 @@
               removable. </description>
         </partition>
 
-        <partition name="APP_b" id="42" type="data">
+        <partition name="APP_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> APPSIZE </size>
@@ -418,7 +418,7 @@
               `/dev/mmcblk0p1`. </description>
         </partition>
 
-        <partition name="UDA" id="43" type="data">
+        <partition name="UDA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -429,7 +429,7 @@
               partition may be mounted and used to store user data. </description>
         </partition>
 
-        <partition name="GPT" id="44" type="GPT">
+        <partition name="GPT" type="GPT">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> -1 </size>


### PR DESCRIPTION
With L4T R32.4.4, the `id` attribute on a partition
is used to specify the partition number.  This allows,
for instance, the APP partition to be physically located
at the end of an SDcard but appear as partition 1 in the
GPT.

Since our custom layouts were derived from an earlier
version of L4T that simply used `id` as a sequence number
for the flashing tools with no external effect, we must
remove those attributes to be compatible with the newer
tools.

Signed-off-by: Matt Madison <matt@madison.systems>