### PR TITLE
Fix delta updates when using cboot.

### DIFF
--- a/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -1,4 +1,13 @@
 #!/bin/sh
+LABELCHARS="AB"
+
+get_bootpart() {
+    current_slot=`nvbootctrl get-current-slot`
+    cfglbl="\"RootfsPart${LABELCHARS:$current_slot:1}\""
+    devnam=`grep -h "$cfglbl:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$'`
+    echo "$devnam"
+}
+
 quiet=
 if [ "$1" = "-n" ]; then
     quiet="yes"
@@ -9,26 +18,34 @@ if [ "$1" = "-n" ]; then
     fi
 fi
 if [ -z "$1" ]; then
-    echo "mender_boot_part=`nvbootctrl get-current-slot`"
+    bootpart=`get_bootpart`
+    echo "mender_boot_part=$bootpart"
     exit 0
 fi
 while [ -n "$1" ]; do
     case "$1" in
-        mender_boot_part|mender_boot_part_hex)
+        mender_boot_part)
+            bootpart=`get_bootpart`
             [ -n "$quiet" ] || echo -n "$1="
-            nvbootctrl get-current-slot
+            echo "$bootpart"
+            ;;
+        mender_boot_part_hex)
+            bootpart=`get_bootpart`
+            bootpart_hex=`echo 16o${bootpart}p | dc`
+            [ -n "$quiet" ] || echo -n "$1="
+            echo "$bootpart_hex"
             ;;
         mender_uboot_separator)
             [ -n "$quiet" ] || echo -n "$1="
             echo "something other than just 1"
             ;;
         upgrade_available)
-            [ -n "$quiet" ] || echo -n "$1="
-	    if [ -e "/var/lib/mender/upgrade_available" ]; then
-		echo "1"
-	    else
-		echo "0"
-	    fi
+            [ -n "$quiet" ] || echo "$1="
+            if [ -e "/var/lib/mender/upgrade_available" ]; then
+                echo "1"
+            else
+                echo "0"
+            fi
            ;;
         *)
            echo "ERR: no such variable: $1" >&2


### PR DESCRIPTION
The Mender delta update module expects mender_boot_part to return the partition number, instead of the boot slot.

Small additional fixes to the fw_printenv script to correctly handle quiet mode.

Signed-off-by: Niels Avonds <niels@nobi.life>